### PR TITLE
Fix two warnings

### DIFF
--- a/c4base/c4Logger.h
+++ b/c4base/c4Logger.h
@@ -14,28 +14,38 @@ class c4Logger;
 class c4Logger : public FairLogger
 {
   public:
-#define c4LOG(severity, x)                                                                                        \
-    if (true)                                                                                                      \
-    {                                                                                                              \
-        std::string fileName(__FILE__);                                                                            \
-        std::stringstream ss;                                                                                      \
-        ss << fileName.substr(fileName.find_last_of("/") + 1) << ":" << __LINE__ << ":" << __FUNCTION__ << "(): "; \
-        LOG(severity) << ss.str() << x;                                                                            \
-    }                                                                                                              \
-    else                                                                                                           \
-        (void)0
+#define c4LOG(severity, x)                                                                                             \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (true)                                                                                                      \
+        {                                                                                                              \
+            std::string fileName(__FILE__);                                                                            \
+            std::stringstream ss;                                                                                      \
+            ss << fileName.substr(fileName.find_last_of("/") + 1) << ":" << __LINE__ << ":" << __FUNCTION__ << "(): "; \
+            LOG(severity) << ss.str() << x;                                                                            \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+        }                                                                                                              \
+    }                                                                                                                  \
+    while (false)
 
-#define c4LOG_IF(severity, condition, x)                                                                     \
-    if (true)                                                                                                 \
-    {                                                                                                         \
-        std::string fileNameif(__FILE__);                                                                     \
-        std::stringstream ssif;                                                                               \
-        ssif << fileNameif.substr(fileNameif.find_last_of("/") + 1) << ":" << __LINE__ << ":" << __FUNCTION__ \
-             << "(): ";                                                                                       \
-        LOG_IF(severity, condition) << ssif.str() << x;                                                       \
-    }                                                                                                         \
-    else                                                                                                      \
-        (void)0
+#define c4LOG_IF(severity, condition, x)                                                                          \
+    do                                                                                                            \
+    {                                                                                                             \
+        if (true)                                                                                                 \
+        {                                                                                                         \
+            std::string fileNameif(__FILE__);                                                                     \
+            std::stringstream ssif;                                                                               \
+            ssif << fileNameif.substr(fileNameif.find_last_of("/") + 1) << ":" << __LINE__ << ":" << __FUNCTION__ \
+                 << "(): ";                                                                                       \
+            LOG_IF(severity, condition) << ssif.str() << x;                                                       \
+        }                                                                                                         \
+        else                                                                                                      \
+        {                                                                                                         \
+        }                                                                                                         \
+    }                                                                                                             \
+    while (false)
 
   private:
     c4Logger();

--- a/c4source/germanium/GermaniumRaw2Cal.cxx
+++ b/c4source/germanium/GermaniumRaw2Cal.cxx
@@ -241,11 +241,11 @@ void GermaniumRaw2Cal::Exec(Option_t* option){
                 c4LOG(fatal, "Detector Mapping not set - please set this using SetDetectorMap to use the Cal Task.");
             }
 
-            if (detector_id == time_machine_delayed_detector_id & crystal_id == time_machine_delayed_crystal_id){
+            if (detector_id == time_machine_delayed_detector_id && crystal_id == time_machine_delayed_crystal_id){
                 new ((*ftime_machine_array)[ftime_machine_array->GetEntriesFast()]) TimeMachineData(0,funcal_hit->Get_channel_trigger_time(),funcal_hit->Get_wr_subsystem_id(),funcal_hit->Get_wr_t());
                 continue;
             }
-            else if (detector_id == time_machine_undelayed_detector_id & crystal_id == time_machine_undelayed_crystal_id){
+            else if (detector_id == time_machine_undelayed_detector_id && crystal_id == time_machine_undelayed_crystal_id){
                 new ((*ftime_machine_array)[ftime_machine_array->GetEntriesFast()]) TimeMachineData(funcal_hit->Get_channel_trigger_time(),0,funcal_hit->Get_wr_subsystem_id(),funcal_hit->Get_wr_t());
                 continue;
             }


### PR DESCRIPTION
Fixes two warnings when compiling c4root

A dangling else warning when using c4LOG - Surrounds the `if`/`else` in a `do`/`while` statement as is the classic C idiom for macros, prevents warnings and ensures you can always use it like it were a function without any issues
Note c4LOG_IF is still broken for performance if used in inner loops

Replace `&` with `&&` in some if checks to suppress a parentheses warning, `&&` is the correct operator anyway (`&` is bitwise)