### PR TITLE
Add time-stitcher options to UcesbSource

### DIFF
--- a/c4source/base/UcesbSource.cxx
+++ b/c4source/base/UcesbSource.cxx
@@ -34,6 +34,8 @@ UcesbSource::UcesbSource(const TString& FileName,
     , fInputFile()
     , fEntryMax(0)
     , fReaders(new TObjArray())
+    , fTimeStitcherPath()
+    , fTimeStitcherOptions()
 {
 }
 
@@ -69,9 +71,17 @@ Bool_t UcesbSource::Init()
     Bool_t status;
     std::ostringstream command;
 
-    /* Call ucesb with this command */
-    command << fUcesbPath << " " << fFileName << " "
-            << "--ntuple=" << fNtupleOptions << ",STRUCT,-"; // just STRUCT
+    if (fTimeStitcherPath.Length()) {
+	command << fTimeStitcherPath << " " << fFileName << " " 
+	    << fTimeStitcherOptions << " --output=- "
+	    << " | " << fUcesbPath << " file://- "
+	    << "--ntuple=" << fNtupleOptions << ",STRUCT,-";
+    }
+    else {
+        /* Call ucesb with this command */
+        command << fUcesbPath << " " << fFileName << " "
+	    << "--ntuple=" << fNtupleOptions << ",STRUCT,-"; // just STRUCT
+    }
 
     if (fLastEventNo != -1)
     {

--- a/c4source/base/UcesbSource.h
+++ b/c4source/base/UcesbSource.h
@@ -70,6 +70,11 @@ class UcesbSource : public FairSource
 
     void SetInputFileName(TString tstr) { fInputFileName = tstr; }
 
+    void SetTimeStitcher(TString tpath, TString topts) {
+		    fTimeStitcherPath = tpath;
+		    fTimeStitcherOptions = topts;
+	}
+
   private:
     /* File descriptor returned from popen() */
     FILE* fFd;
@@ -98,6 +103,9 @@ class UcesbSource : public FairSource
     TString fInputFileName;
     std::ifstream fInputFile;
     Int_t fEntryMax;
+
+    TString fTimeStitcherPath;
+    TString fTimeStitcherOptions;
 
   public:
     


### PR DESCRIPTION
This adds a ucesbsource option that lets you use a time-stitcher (modified ucesb) before the ucesb unpacker to time-stitch events and build AIDA/DTAS events

Example macro usage:
```cpp
UcesbSource* source = new UcesbSource(filename, ntuple_options, ucesb_path, &ucesb_struct, sizeof(ucesb_struct));
source->SetTimeStitcher("/home/nhubbard/c4root/ucesb-ts/despec/despec", "--aida --time-stitch=wr,2000");
```

Tested and seems to work, but could be considered quite basic, better steering macro usage could be considered